### PR TITLE
Feature/blank screen

### DIFF
--- a/pympress/ui.py
+++ b/pympress/ui.py
@@ -97,6 +97,9 @@ class UI:
     #: Fullscreen toggle. By default, don't start in fullscreen mode.
     fullscreen = False
 
+    #: Blanked screen toggle.
+    blanked = False
+
     #: Current :class:`~pympress.document.Document` instance.
     doc = None
 
@@ -170,6 +173,7 @@ class UI:
             <menuitem action="Reset timer"/>
             <menuitem action="Fullscreen"/>
             <menuitem action="Notes mode"/>
+            <menuitem action="Blank screen"/>
           </menu>
           <menu action="Help">
             <menuitem action="About"/>
@@ -197,6 +201,7 @@ class UI:
             ("Pause timer",  None,           "_Pause timer", "p",  None, self.switch_pause,      True),
             ("Fullscreen",   None,           "_Fullscreen",  "f",  None, self.switch_fullscreen, False),
             ("Notes mode",   None,           "_Note mode",   "n",  None, self.switch_mode,       self.notes_mode),
+            ("Blank screen", None,           "_Blank screen","b",  None, self.switch_blank,      False),
         ])
         ui_manager.insert_action_group(action_group)
 
@@ -468,17 +473,22 @@ class UI:
         :param event: the event that occured
         :type  event: :class:`gtk.gdk.Event`
         """
+
         if event.type == gtk.gdk.KEY_PRESS:
             name = gtk.gdk.keyval_name(event.keyval)
 
             if name in ["Right", "Down", "Page_Down", "space"]:
-                self.doc.goto_next()
+                if not self.blanked:
+                    self.doc.goto_next()
             elif name in ["Left", "Up", "Page_Up", "BackSpace"]:
-                self.doc.goto_prev()
+                if not self.blanked:
+                    self.doc.goto_prev()
             elif name == 'Home':
-                self.doc.goto_home()
+                if not self.blanked:
+                    self.doc.goto_home()
             elif name == 'End':
-                self.doc.goto_end()
+                if not self.blanked:
+                    self.doc.goto_end()
             elif (name.upper() in ["F", "F11"]) \
                 or (name == "Return" and event.state & gtk.gdk.MOD1_MASK) \
                 or (name.upper() == "L" and event.state & gtk.gdk.CONTROL_MASK):
@@ -498,12 +508,15 @@ class UI:
                     self.switch_pause()
                 elif name.upper() == "N":
                     self.switch_mode()
+                elif name.upper() == "B":
+                    self.switch_blank()
 
         elif event.type == gtk.gdk.SCROLL:
-            if event.direction in [gtk.gdk.SCROLL_RIGHT, gtk.gdk.SCROLL_DOWN]:
-                self.doc.goto_next()
-            else:
-                self.doc.goto_prev()
+            if not self.blanked:
+                if event.direction in [gtk.gdk.SCROLL_RIGHT, gtk.gdk.SCROLL_DOWN]:
+                    self.doc.goto_next()
+                else:
+                    self.doc.goto_prev()
 
         else:
             print "Unknown event %s" % event.type
@@ -798,6 +811,14 @@ class UI:
             self.cache.set_widget_type("p_da_next", PDF_CONTENT_PAGE)
 
         self.on_page_change(False)
+
+    def switch_blank(self, widget=None, event=None):
+        if self.blanked:
+            self.blanked = False
+            self.c_da.show()
+        else:
+            self.blanked = True
+            self.c_da.hide()
 
 
 ##

--- a/pympress/ui.py
+++ b/pympress/ui.py
@@ -99,19 +99,25 @@ class UI:
 
     #: Blanked screen toggle.
     blanked = False
+    #: Whether to blank to a white or black screen
+    blank_to_white = False
 
     #: Current :class:`~pympress.document.Document` instance.
     doc = None
 
     #: Whether to use notes mode or not
     notes_mode = False
+    
+    #: Black color
+    color_black = gtk.gdk.Color(0, 0, 0)
+    #: White color
+    color_white = gtk.gdk.Color('#FFFFFF')
 
     def __init__(self, doc):
         """
         :param doc: the current document
         :type  doc: :class:`pympress.document.Document`
         """
-        black = gtk.gdk.Color(0, 0, 0)
 
         # Common to both windows
         icon_list = pympress.util.load_icons()
@@ -125,13 +131,14 @@ class UI:
         # Content window
         self.c_win.set_title("pympress content")
         self.c_win.set_default_size(800, 600)
-        self.c_win.modify_bg(gtk.STATE_NORMAL, black)
+        self.c_win.modify_bg(gtk.STATE_NORMAL, self.color_black)
         self.c_win.connect("delete-event", gtk.main_quit)
         self.c_win.set_icon_list(*icon_list)
 
-        self.c_frame.modify_bg(gtk.STATE_NORMAL, black)
+        self.c_frame.modify_bg(gtk.STATE_NORMAL, self.color_black)
+        self.c_frame.set_shadow_type(gtk.SHADOW_NONE)
 
-        self.c_da.modify_bg(gtk.STATE_NORMAL, black)
+        self.c_da.modify_bg(gtk.STATE_NORMAL, self.color_black)
         self.c_da.connect("expose-event", self.on_expose)
         self.c_da.set_name("c_da")
         if self.notes_mode:
@@ -174,6 +181,7 @@ class UI:
             <menuitem action="Fullscreen"/>
             <menuitem action="Notes mode"/>
             <menuitem action="Blank screen"/>
+            <menuitem action="Blank to white"/>
           </menu>
           <menu action="Help">
             <menuitem action="About"/>
@@ -202,6 +210,7 @@ class UI:
             ("Fullscreen",   None,           "_Fullscreen",  "f",  None, self.switch_fullscreen, False),
             ("Notes mode",   None,           "_Note mode",   "n",  None, self.switch_mode,       self.notes_mode),
             ("Blank screen", None,           "_Blank screen","b",  None, self.switch_blank,      False),
+            ("Blank to white", None,         "Blank to _white", "w", None, self.switch_blank_to_white, False),
         ])
         ui_manager.insert_action_group(action_group)
 
@@ -234,7 +243,7 @@ class UI:
         self.eb_cur.set_visible_window(False)
         self.eb_cur.connect("event", self.on_label_event)
         vbox.pack_start(self.eb_cur, False, False, 10)
-        self.p_da_cur.modify_bg(gtk.STATE_NORMAL, black)
+        self.p_da_cur.modify_bg(gtk.STATE_NORMAL, self.color_black)
         self.p_da_cur.connect("expose-event", self.on_expose)
         self.p_da_cur.set_name("p_da_cur")
         if self.notes_mode:
@@ -263,7 +272,7 @@ class UI:
         self.label_next.set_justify(gtk.JUSTIFY_CENTER)
         self.label_next.set_use_markup(True)
         vbox.pack_start(self.label_next, False, False, 10)
-        self.p_da_next.modify_bg(gtk.STATE_NORMAL, black)
+        self.p_da_next.modify_bg(gtk.STATE_NORMAL, self.color_black)
         self.p_da_next.connect("expose-event", self.on_expose)
         self.p_da_next.set_name("p_da_next")
         if self.notes_mode:
@@ -512,6 +521,8 @@ class UI:
                     self.switch_mode()
                 elif name.upper() == "B":
                     self.switch_blank()
+                elif name.upper() == "W":
+                    self.switch_blank_to_white()
 
         elif event.type == gtk.gdk.SCROLL:
             if not self.blanked:
@@ -818,9 +829,23 @@ class UI:
         if self.blanked:
             self.blanked = False
             self.c_da.show()
+            if not self.blank_to_white:
+                self.c_win.modify_bg(gtk.STATE_NORMAL, self.color_black)
         else:
             self.blanked = True
             self.c_da.hide()
+            if self.blank_to_white:
+                self.c_win.modify_bg(gtk.STATE_NORMAL, self.color_white)
+
+
+    def switch_blank_to_white(self, widget=None, event=None):
+        self.blank_to_white = not self.blank_to_white
+        if self.blank_to_white:
+            self.c_win.modify_bg(gtk.STATE_NORMAL, self.color_white)
+
+        else:
+            self.c_win.modify_bg(gtk.STATE_NORMAL, self.color_black)
+        self.on_page_change(False)
 
 
 ##

--- a/pympress/ui.py
+++ b/pympress/ui.py
@@ -498,7 +498,7 @@ class UI:
             elif name == 'End':
                 if not self.blanked:
                     self.doc.goto_end()
-            elif (name.upper() == "F11") \
+            elif (name.upper() in ["F5", "F11"]) \
                 or (name == "Return" and event.state & gtk.gdk.MOD1_MASK) \
                 or (name.upper() == "L" and event.state & gtk.gdk.CONTROL_MASK):
                 self.switch_fullscreen()
@@ -508,6 +508,8 @@ class UI:
                 self.switch_pause()
             elif name.upper() == "R":
                 self.reset_timer()
+            elif name == "period":
+                self.switch_blank()
 
             # Some key events are already handled by toggle actions in the
             # presenter window, so we must handle them in the content window

--- a/pympress/ui.py
+++ b/pympress/ui.py
@@ -489,7 +489,7 @@ class UI:
             elif name == 'End':
                 if not self.blanked:
                     self.doc.goto_end()
-            elif (name.upper() in ["F", "F11"]) \
+            elif (name.upper() == "F11") \
                 or (name == "Return" and event.state & gtk.gdk.MOD1_MASK) \
                 or (name.upper() == "L" and event.state & gtk.gdk.CONTROL_MASK):
                 self.switch_fullscreen()
@@ -506,6 +506,8 @@ class UI:
             elif widget is self.c_win:
                 if name.upper() == "P":
                     self.switch_pause()
+                elif name.upper() == "F":
+                    self.switch_fullscreen()
                 elif name.upper() == "N":
                     self.switch_mode()
                 elif name.upper() == "B":


### PR DESCRIPTION
Hello, 

I've added the functionality to blank the screen, that is, show an empty screen. The screen can either be black or white. With the shortcut `B` the current slide will be hidden, or shown again. While hidden the navigation through the slides is disabled. 

With the shortcut `W` you can switch the background of the content window from black to white and back again.
